### PR TITLE
feat: add routine timing customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,12 +255,56 @@
       gap: 10px;
     }
 
-    .modal-content input[type="text"] {
-      width: 100%;
+    .modal-content input[type="text"],
+    .modal-content input[type="number"] {
+      flex: 1;
       padding: 8px;
-      margin-bottom: 10px;
       border-radius: 5px;
       border: 1px solid #ccc;
+    }
+
+    .settings-field {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+
+    .info-icon {
+      position: relative;
+      display: inline-block;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.4);
+      color: #fff;
+      font-size: 12px;
+      font-weight: bold;
+      text-align: center;
+      line-height: 18px;
+      cursor: pointer;
+    }
+
+    .info-icon::after {
+      content: attr(data-info);
+      position: absolute;
+      bottom: 125%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #333;
+      color: #fff;
+      padding: 5px 8px;
+      border-radius: 5px;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      z-index: 10;
+    }
+
+    .info-icon:hover::after,
+    .info-icon.show::after {
+      opacity: 1;
     }
 
     @media (max-width: 600px) {
@@ -319,9 +363,22 @@
 <div id="routineModal" class="modal hidden">
   <div class="modal-content">
     <h2>Edit Routine</h2>
+    <div class="settings-field">
+      <label for="workDurationInput">Work (s):</label>
+      <input id="workDurationInput" type="number" min="1" value="60">
+      <span class="info-icon" data-info="Duration of each exercise in seconds">i</span>
+    </div>
+    <div class="settings-field">
+      <label for="restDurationInput">Break (s):</label>
+      <input id="restDurationInput" type="number" min="0" value="30">
+      <span class="info-icon" data-info="Duration of breaks in seconds">i</span>
+    </div>
     <div id="routineEditor"></div>
     <button id="addExerciseBtn" class="add-exercise">➕ Add Exercise</button>
-    <input id="routineNameInput" type="text" placeholder="Routine name">
+    <div class="settings-field">
+      <input id="routineNameInput" type="text" placeholder="Routine name">
+      <span class="info-icon" data-info="Name used when saving this routine">i</span>
+    </div>
     <div class="modal-actions">
       <button id="saveRoutineModalBtn">💾 Save</button>
       <button id="cancelRoutineModalBtn">✖ Cancel</button>
@@ -392,6 +449,9 @@
 
       this.currentRoutineName = 'Default';
 
+      this.workDuration = 60;
+      this.restDuration = 30;
+
       this.currentPhase = 'ready'; // ready, countdown, exercise, rest, finished
       this.currentExercise = 0;
       this.timeLeft = 0;
@@ -406,6 +466,7 @@
       this.initElements();
       this.setupEventListeners();
       this.enableDragAndDrop();
+      this.setupInfoTooltips();
       this.renderWorkoutList();
       this.updateDisplay();
     }
@@ -472,6 +533,8 @@
       this.saveRoutineModalBtn = document.getElementById('saveRoutineModalBtn');
       this.cancelRoutineModalBtn = document.getElementById('cancelRoutineModalBtn');
       this.routineNameInput = document.getElementById('routineNameInput');
+      this.workDurationInput = document.getElementById('workDurationInput');
+      this.restDurationInput = document.getElementById('restDurationInput');
 
     }
 
@@ -493,7 +556,7 @@
     renderWorkoutList() {
       this.workoutList.innerHTML = this.exercises.map((exercise, index) =>
               `<div class="exercise-item" id="exercise-${index}">
-                        ${index + 1}. ${exercise} - 1 min
+                        ${index + 1}. ${exercise} - ${this.workDuration}s
                     </div>`
       ).join('');
     }
@@ -501,6 +564,8 @@
     openRoutineModal() {
       this.routineEditor.innerHTML = '';
       this.exercises.forEach(ex => this.addRoutineField(ex));
+      this.workDurationInput.value = this.workDuration;
+      this.restDurationInput.value = this.restDuration;
       this.routineNameInput.value = this.currentRoutineName || '';
       this.routineModal.classList.remove('hidden');
     }
@@ -515,7 +580,7 @@
         const key = localStorage.key(i);
         try {
           const value = JSON.parse(localStorage.getItem(key));
-          if (Array.isArray(value)) {
+          if (Array.isArray(value) || (value && Array.isArray(value.exercises))) {
             const btn = document.createElement('button');
             btn.textContent = key;
             btn.addEventListener('click', () => {
@@ -586,6 +651,18 @@
       });
     }
 
+    setupInfoTooltips() {
+      document.querySelectorAll('.info-icon').forEach(icon => {
+        icon.addEventListener('click', e => {
+          e.stopPropagation();
+          icon.classList.toggle('show');
+        });
+      });
+      document.addEventListener('click', () => {
+        document.querySelectorAll('.info-icon.show').forEach(i => i.classList.remove('show'));
+      });
+    }
+
     getDragAfterElement(container, y) {
       const els = [...container.querySelectorAll('.routine-item:not(.dragging)')];
       return els.reduce((closest, child) => {
@@ -601,16 +678,20 @@
 
     saveRoutineFromModal() {
       const name = this.routineNameInput.value.trim();
-      const items = Array.from(this.routineEditor.querySelectorAll('input'))
+      const items = Array.from(this.routineEditor.querySelectorAll('.routine-item input'))
         .map(i => i.value.trim())
         .filter(Boolean);
+      const work = parseInt(this.workDurationInput.value, 10) || 60;
+      const rest = parseInt(this.restDurationInput.value, 10) || 30;
       if (!name || items.length === 0) {
         alert('Please provide a name and at least one exercise.');
         return;
       }
       this.exercises = items;
       this.currentRoutineName = name;
-      localStorage.setItem(name, JSON.stringify(items));
+      this.workDuration = work;
+      this.restDuration = rest;
+      localStorage.setItem(name, JSON.stringify({ exercises: items, work, rest }));
       this.renderWorkoutList();
       this.resetWorkout();
       this.closeRoutineModal();
@@ -620,13 +701,21 @@
       const data = localStorage.getItem(name);
       if (data) {
         try {
-          const arr = JSON.parse(data);
-          if (Array.isArray(arr) && arr.length) {
-            this.exercises = arr;
-            this.currentRoutineName = name;
-            this.renderWorkoutList();
-            this.resetWorkout();
+          const obj = JSON.parse(data);
+          if (Array.isArray(obj)) {
+            this.exercises = obj;
+            this.workDuration = 60;
+            this.restDuration = 30;
+          } else if (obj && Array.isArray(obj.exercises)) {
+            this.exercises = obj.exercises;
+            this.workDuration = obj.work || 60;
+            this.restDuration = obj.rest || 30;
+          } else {
+            return;
           }
+          this.currentRoutineName = name;
+          this.renderWorkoutList();
+          this.resetWorkout();
         } catch (e) {}
       }
     }
@@ -638,7 +727,7 @@
         const key = localStorage.key(i);
         try {
           const value = JSON.parse(localStorage.getItem(key));
-          if (Array.isArray(value)) keys.push(key);
+          if (Array.isArray(value) || (value && Array.isArray(value.exercises))) keys.push(key);
         } catch (e) {}
       }
       keys.forEach(k => localStorage.removeItem(k));
@@ -715,8 +804,8 @@
 
     startExercise() {
       this.currentPhase = 'exercise';
-      this.timeLeft = 60;
-      this.totalTime = 60;
+      this.timeLeft = this.workDuration;
+      this.totalTime = this.workDuration;
       this.playStartExerciseSound(); // 👈 Add this line
       this.updateDisplay();
 
@@ -724,8 +813,8 @@
 
     startRest() {
       this.currentPhase = 'rest';
-      this.timeLeft = 30;
-      this.totalTime = 30;
+      this.timeLeft = this.restDuration;
+      this.totalTime = this.restDuration;
       this.updateDisplay();
     }
 


### PR DESCRIPTION
## Summary
- allow editing work and break durations in routine editor with helpful info tooltips
- save and load custom timings alongside routines
- apply customized durations during workout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d3478f9d4832694435e3c07e3576c